### PR TITLE
reboot Micro-PET into the SPI Flash IPL bootloader

### DIFF
--- a/edit.asm
+++ b/edit.asm
@@ -67,6 +67,8 @@ DEFAULTBO = 0   ; ColourPET Border colour       0 to 15 RGBI
 BYPASSFG  = 5   ; ColourPET Bypass FG     	0 to 15 RGBI			Colours when AUTOSTART is bypassed.
 BYPASSBG  = 0   ; ColourPET Bypass BG     	0 to 15 RGBI
 
+UPET      = 1   ; Is a Micro-PET                0=No, 1=Yes                     For special Reboot
+
 MOT6845   = 0   ; Is CRTC a Motorola6845?       0=No, 1=Yes			Probably 0=No for compatibility.
 REBOOT    = 0	; Add keyboard reboot? 		0=No, 1=Yes
 EXECUDESK = 0	; Add Execudesk Menu?		0=No, 1=Yes, 2=Yes/OPTROM>0	Note: Requires BOOT to TEXT mode!

--- a/editreboot.asm
+++ b/editreboot.asm
@@ -23,7 +23,11 @@ CheckLoop
 		DEY					; ROW=ROW-1
 		BPL CheckLoop				; Get more if not <0
 
-		JMP ($FFFC)				; All keys match, so reset!
+		!IF UPET=1 {
+			JMP RebootUPet
+		} ELSE {
+			JMP ($FFFC)			; All keys match, so reset!
+		}
 
 CheckOut	RTS
 

--- a/editrom.asm
+++ b/editrom.asm
@@ -55,6 +55,7 @@ DBLINE = SCREEN_RAM + 24 * COLUMNS					; Calculate bottom line of screen for deb
 		!IF SS40 = 1      { !SOURCE "editsoft40.asm" }
 		!IF BACKARROW = 2 { !SOURCE "editbarrow.asm" }
 		!IF EXECUDESK > 0 { !SOURCE "execudesk.asm" }
+		!IF UPET = 1      { !SOURCE "upet.asm" }
 INFOSTRING	
 		!IF INFO > 0      { !SOURCE "info.asm" }
 

--- a/upet.asm
+++ b/upet.asm
@@ -1,0 +1,54 @@
+; PET/CBM EDIT ROM - Micro-PET Extensions (C)2021 Andre Fachat
+; ================
+; Editor-ROM extensions for the Micro-PET:
+; 
+; Currently only a hook into the Soft Reboot is used, to get to the Micro-PET
+; Boot screen, where the actual type of PET can be selected.
+;
+; Some future extensions could be graphics options menu, or a speed selector
+
+!IF REBOOT=1 {
+
+SPEED=$e803
+LOW32K=$e802
+MEMMAP=$e801
+VCTRL=$e800
+
+SPI=$e808
+SPIDATA=$e809
+
+FLASH=$01
+
+RebootUPet
+		sei
+
+		lda #0
+		sta SPEED	; 1MHz to make sure not to overrun SPI
+		sta MEMMAP	; all RAM (writeable)
+		sta VCTRL
+		sta LOW32K	
+
+		lda #FLASH
+		sta SPI
+		lda #3		; SPI Flash READ
+		sta SPIDATA
+		lda #0
+		sta SPIDATA
+		sta SPIDATA
+		sta SPIDATA
+		lda SPIDATA	; trigger first byte
+
+		ldx #0
+loop		lda SPIDATA
+		sta $ff00,x
+		inx
+		bne loop
+
+		stx SPI
+
+		JMP ($FFFC)
+
+
+}
+
+


### PR DESCRIPTION
This adds a "UPET" configuration variable. 
For now this only changes the soft reboot (if enabled), into booting into the Micro-PET's IPL boot loader instead of back into the PET ROM (from the IPL boot loader the type of PET can then be selected)