### PR TITLE
Make CODEBASE 0 assemble with C64 keyboard scanner...

### DIFF
--- a/banner.asm
+++ b/banner.asm
@@ -147,7 +147,7 @@
 		!byte $92,$E9,$5		; <OFF><diag block><WHT>
 
 !IF UPET=1 {
-		!pet "  the ultra-pet development prototype"
+		!pet "  the ultra-pet prototype"
 } ELSE {
 		!pet "  the commodore colourpet"
 }

--- a/code0overflow.asm
+++ b/code0overflow.asm
@@ -1,0 +1,50 @@
+; PET/CBM EDIT ROM - Extended ROM Code
+; ================
+; This code goes in the upper half of the 4K EDIT ROMS
+; NOTE: The code from $E800-E8FF is not visible - fill with copyright or comments
+;
+;*=e800
+;*********************************************************************************************************
+;** Hidden I/O Area used for Copyright and version info text
+;*********************************************************************************************************
+!IF CRUNCH=0 {
+		!SOURCE "copyright-4v4e.asm"			; Use Commodore's info block	
+		!FILL $e900-*,$ff 				; pad
+} ELSE {
+		!SOURCE "io.asm"				; Include our own info text with settings
+}
+
+;*=e900
+
+;*********************************************************************************************************
+;** Custom Features go here. Set CRUNCH=1 to make space available!!!!!!
+;** There is limited space (about 600 bytes with CRUNCH=1 - see below) to add features.
+;*********************************************************************************************************
+
+;!IF (COLOURPET + ESCCODES + WEDGE + EXECUDESK + SS40 + AUTORUN > 0) | (BACKARROW=2) {
+;
+;		!IF EXECUDESK = 1 { !SOURCE "execudesk.asm" }		; 1,514 bytes... Don't even think about it ;-)
+;		!IF AUTORUN   = 1 { !SOURCE "editautorun.asm" }		; 70+ bytes
+;		!IF BANNER > 0    { !SOURCE "editbanner.asm" }		; 120+ bytes
+;		!IF WEDGE = 1	  { !SOURCE "editwedge.asm" }		; 560+ bytes
+;		!IF COLOURPET = 1 { !SOURCE "colourpetsubs.asm" }	;
+;		!IF ESCCODES = 1  { !SOURCE "editescape.asm" }		; 460+ bytes
+;		!IF REBOOT = 1    { !SOURCE "editreboot.asm" }		; 28 bytes
+;		!IF SS40 = 1      { !SOURCE "editsoft40.asm" }		;
+;		!IF BACKARROW = 2 { !SOURCE "editbarrow.asm" }		; 21 bytes
+;}
+
+;*********************************************************************************************************
+;** Start of Extended Code Area [E900]
+;*********************************************************************************************************
+
+;*********************************************************************************************************
+;** Extended Keyboard Scanning Tables [EE85]
+;*********************************************************************************************************
+
+!IF (KEYSCAN=3) {
+		!SOURCE "keyboard-tables3.asm"
+}
+
+!fill $f000-*,$00 				;pad to 4K
+

--- a/editrom.asm
+++ b/editrom.asm
@@ -39,6 +39,14 @@
 	!IF CODEBASE=1 {!SOURCE "editrom80.asm"}			; 80-column CODEBASE
 	!IF CODEBASE=2 {!SOURCE "editrom82.asm"}			; 80-column EXTENDED CODEBASE
 
+;=======================================================================
+; CODEBASE 0 Overflow Code
+;=======================================================================
+; This code is included only for Codebase 0, and only contains feature
+; code that overflows the first 2k (e.g. C64 keyboard tables)
+
+	!IF CODEBASE = 0 {!SOURCE "code0overflow.asm" }
+
 ;----------------------- Determine if we need to generate more code!
 ; We must include this area if:
 ;   1) We are using CODEBASE 2

--- a/keyboard.asm
+++ b/keyboard.asm
@@ -10,4 +10,5 @@
 !if KEYSCAN=0 { !source "keyboard-tables1.asm" }	; Graphic (Normal) Keyboard Scanner - Simple
 !if KEYSCAN=1 { !source "keyboard-tables1.asm" }	; Business Keyboard Scanner - Simple with code for specific shifted keys
 !if KEYSCAN=2 { !source "keyboard-tables2.asm" }	; Extended Keyboard Scanner - Two Tables (Normal and Shifted)
-!if KEYSCAN=3 { !source "keyboard-tables3.asm" }	; C64 keyboard tables
+!if ((CODEBASE>0) & (KEYSCAN=3)) { 
+		!source "keyboard-tables3.asm" }	; C64 keyboard tables (only on newer codebases; put in ext space on codebase 0)


### PR DESCRIPTION
... by overflowing the C64 keyboard scanner tables into the extended ROM area above $e9xx