### PR TITLE
Shuffling some codebase 0 code

### DIFF
--- a/code0overflow.asm
+++ b/code0overflow.asm
@@ -3,17 +3,6 @@
 ; This code goes in the upper half of the 4K EDIT ROMS
 ; NOTE: The code from $E800-E8FF is not visible - fill with copyright or comments
 ;
-;*=e800
-;*********************************************************************************************************
-;** Hidden I/O Area used for Copyright and version info text
-;*********************************************************************************************************
-!IF CRUNCH=0 {
-		!SOURCE "copyright-4v4e.asm"			; Use Commodore's info block	
-		!FILL $e900-*,$ff 				; pad
-} ELSE {
-		!SOURCE "io.asm"				; Include our own info text with settings
-}
-
 ;*=e900
 
 ;*********************************************************************************************************
@@ -24,7 +13,6 @@
 ;!IF (COLOURPET + ESCCODES + WEDGE + EXECUDESK + SS40 + AUTORUN > 0) | (BACKARROW=2) {
 ;
 ;		!IF EXECUDESK = 1 { !SOURCE "execudesk.asm" }		; 1,514 bytes... Don't even think about it ;-)
-;		!IF AUTORUN   = 1 { !SOURCE "editautorun.asm" }		; 70+ bytes
 ;		!IF BANNER > 0    { !SOURCE "editbanner.asm" }		; 120+ bytes
 ;		!IF WEDGE = 1	  { !SOURCE "editwedge.asm" }		; 560+ bytes
 ;		!IF COLOURPET = 1 { !SOURCE "colourpetsubs.asm" }	;
@@ -46,5 +34,11 @@
 		!SOURCE "keyboard-tables3.asm"
 }
 
-!fill $f000-*,$00 				;pad to 4K
+!IF (BACKARROW = 1) {
+		!SOURCE "editbarrow.asm"
+}
+
+!IF (COLOURPET = 1) {
+		!SOURCE "screen1c.asm"
+}
 

--- a/code0overflow.asm
+++ b/code0overflow.asm
@@ -34,10 +34,6 @@
 		!SOURCE "keyboard-tables3.asm"
 }
 
-!IF (BACKARROW = 1) {
-		!SOURCE "editbarrow.asm"
-}
-
 !IF (COLOURPET = 1) {
 		!SOURCE "screen1c.asm"
 }

--- a/colourpetsubs.asm
+++ b/colourpetsubs.asm
@@ -139,7 +139,13 @@ CCRAM1
 
 ColourPET_SyncPointersX
 		STA ScrPtr				; Pointer: Current Screen Line Address LO
+!IF (CODEBASE=0) { 
+		LDA CLine_Addr_Hi,X			; Screen Line Addresses HI
+		AND #%11110111 
+} ELSE {
 		LDA Line_Addr_Hi,X			; Screen Line Addresses HI
+}
+
 		STA ScrPtr+1         			; Pointer: Current Screen Line Address HI
 
 		LDA CLine_Addr_Lo,X			; Colour Screen Line Addresses LO
@@ -158,7 +164,12 @@ ColourPET_SyncPointersX
 ColourPET_SyncPointers
 		LDA Line_Addr_Lo+1,X			; Screen line address table LO + 1
 		STA SAL					; Pointer: Tape Buffer/ Screen Scrolling
-		LDA Line_Addr_Hi+1,X			; Screen line address table HI + 1
+!IF (CODEBASE=0) { 
+		LDA CLine_Addr_Hi+1,X			; Screen Line Addresses HI
+		AND #%11110111 
+} ELSE {
+		LDA Line_Addr_Hi+1,X			; Screen Line Addresses HI
+}
 		STA SAL+1				; Pointer: Tape Buffer/ Screen Scrolling
 
 		LDA CLine_Addr_Lo+1,X     		; Screen Line address table LO + 1
@@ -170,7 +181,12 @@ ColourPET_SyncPointers
 ColourPET_SyncPointers2
 		LDA Line_Addr_Lo-1,X			; Screen line address table LO - 1
 		STA SAL					; Pointer: Tape Buffer/ Screen Scrolling
-		LDA Line_Addr_Hi-1,X			; Screen line address table HI - 1
+!IF (CODEBASE=0) { 
+		LDA CLine_Addr_Hi-1,X			; Screen Line Addresses HI
+		AND #%11110111 
+} ELSE {
+		LDA Line_Addr_Hi-1,X			; Screen Line Addresses HI
+}
 		STA SAL+1				; Pointer: Tape Buffer/ Screen Scrolling
 
 		LDA CLine_Addr_Lo-1,X     		; Screen Line address table LO - 1

--- a/editrom.asm
+++ b/editrom.asm
@@ -40,12 +40,11 @@
 	!IF CODEBASE=2 {!SOURCE "editrom82.asm"}			; 80-column EXTENDED CODEBASE
 
 ;=======================================================================
-; CODEBASE 0 Overflow Code
+; CODEBASE Overflow Code
 ;=======================================================================
 ; This code is included only for Codebase 0, and only contains feature
 ; code that overflows the first 2k (e.g. C64 keyboard tables)
 
-	!IF CODEBASE = 0 {!SOURCE "code0overflow.asm" }
 
 ;----------------------- Determine if we need to generate more code!
 ; We must include this area if:
@@ -53,7 +52,7 @@
 ;   2) Certain EXTended features are enabled
 ;   3) BACKARROW feature needs relocating.
 
-	!IF (CODEBASE=2) | ((COLOURPET + ESCCODES + WEDGE + EXECUDESK + SS40 + AUTORUN + KEYRESET) > 0) | (BACKARROW=2) {
+	!IF ((CODEBASE=2) | ((COLOURPET + ESCCODES + WEDGE + EXECUDESK + SS40 + AUTORUN + KEYRESET) > 0) | (BACKARROW=2) | (CODEBASE=0 & KEYSCAN=3)) {
 
 ;=======================================================================
 ; EXT 4K Edit ROM code starts here
@@ -76,6 +75,8 @@
 ; CODEBASE 2 Code
 ;=======================================================================
 ; This code is included only for Codebase 2
+
+
 
 	!IF CODEBASE = 2 {!SOURCE "editromext.asm" }
 
@@ -103,6 +104,8 @@
 		!IF BANNER > 0    { !SOURCE "editbanner.asm" }
 		!IF WEDGE = 1	  { !SOURCE "editwedge.asm" }		
 	}
+
+	!IF CODEBASE = 0 {!SOURCE "code0overflow.asm" }
 
 	;----- These features require ESC codes
 

--- a/editrom40.asm
+++ b/editrom40.asm
@@ -1346,8 +1346,10 @@ POWERSOF2       !byte $80,$40,$20,$10,$08,$04,$02,$01	; BIT table
 ;*********************************************************************************************************
 ;** SMALL PATCHES HERE
 ;*********************************************************************************************************
+; note - these had to be moved to code0overflow.asm to make place for 
+; colourpet and other code
 
-!IF BACKARROW =1 { !SOURCE "editbarrow.asm" }		; Patch for Back Arrow
+;!IF BACKARROW =1 { !SOURCE "editbarrow.asm" }		; Patch for Back Arrow
 
 ;*********************************************************************************************************
 ;** FILLER

--- a/editrom40.asm
+++ b/editrom40.asm
@@ -1349,7 +1349,7 @@ POWERSOF2       !byte $80,$40,$20,$10,$08,$04,$02,$01	; BIT table
 ; note - these had to be moved to code0overflow.asm to make place for 
 ; colourpet and other code
 
-;!IF BACKARROW =1 { !SOURCE "editbarrow.asm" }		; Patch for Back Arrow
+!IF BACKARROW =1 { !SOURCE "editbarrow.asm" }		; Patch for Back Arrow
 
 ;*********************************************************************************************************
 ;** FILLER

--- a/editrom40cls.asm
+++ b/editrom40cls.asm
@@ -62,3 +62,8 @@ CLS_LOOP	STA SCREEN_RAM,X			; LOOP[  Screen RAM page 1
 }
 		INX					;   Next position
 		BNE CLS_LOOP				; ] Loop back for more
+
+!IF (COLOURPET=1) {
+		JSR ClearColourRAM
+}
+

--- a/editrom80.asm
+++ b/editrom80.asm
@@ -1380,7 +1380,7 @@ SOUND_TAB	!byte $0e,$1e,$3e,$7e,$3e,$1e,$0e	; BELL chime values
 ;** Small patches here  [E787]
 ;*********************************************************************************************************
 
-!IF BACKARROW >0 { !SOURCE "editbarrow.asm" }		; Patch for BackArrow toggling of screen mode
+!IF BACKARROW =1 { !SOURCE "editbarrow.asm" }		; Patch for BackArrow toggling of screen mode
 
 ;#########################################################################################################
 !IF CRUNCH=0 {	!byte $cd }		; to match 901474-04


### PR DESCRIPTION
So, now assembles all the edit.asm files I have for the UltraPET, with codebase 0 for 40 cols and codebase 1 for 80 cols
- with or without c64kbd
- with or without extensions (esccodes, wedge, reset, backarrow, banner)
- with or without colour

Except that colour does not yet work with codebase 0 - results in strange runtime behaviour