### PR TITLE
fix too much code for codebase=0 & keyscan=3

### DIFF
--- a/editrom_hi.asm
+++ b/editrom_hi.asm
@@ -83,7 +83,7 @@
 
 	;----- These features can stand alone
 
-	!IF KEYSCAN=3	  { !SOURCE "keyboard-tables3.asm" }	; C64 Keyboard Scanning Tables
+	!IF (CODEBASE=0 & KEYSCAN=3)	  { !SOURCE "keyboard-tables3.asm" }	; C64 Keyboard Scanning Tables
 	!IF KEYRESET = 1  { !SOURCE "editreboot.asm" }		; Keyboard Reset Code
 	!IF BACKARROW = 2 { !SOURCE "editbarrow.asm" }		; Back Arrow "hack" Code
 	!IF EXECUDESK > 0 { !SOURCE "execudesk.asm" }		; Execudesk Code


### PR DESCRIPTION
On codebase 0, with C64 keyboard the keyscan tables were included twice.