### PR TITLE
Fix ColourPET duplicate symbol definition build errors

### DIFF
--- a/editrom40.asm
+++ b/editrom40.asm
@@ -64,7 +64,7 @@ RESET_EDITOR
 ; 40/80 column option. However, if we are using SS40 or COLOURPET then the routine will not
 ; fit and must be relocated!
 
-!IF SS40 = 0 { !SOURCE "editrom40cls.asm"
+!IF (SS40 + COLOURPET) = 0 { !SOURCE "editrom40cls.asm"
 		} ELSE { JMP WIN_CLEAR }
 
 ;*********************************************************************************************************


### PR DESCRIPTION
Building the ColourPET 40-column edit ROM with the command:

```text
acme config-custom/!colourpet40.asm
```

failed with "Symbol already defined" errors because `editrom40cls.asm` was included twice:

1. In `editrom40.asm`: condition `!IF SS40 = 0` was true (SS40=0)
2. In `editrom40hi.asm`: condition `!IF (SS40 + COLOURPET) > 0` was also true (COLOURPET=1)

The proposed fix is to change the condition in `editrom40.asm` from:

```asm
!IF SS40 = 0 { !SOURCE "editrom40cls.asm"
```

to:

```asm
!IF (SS40 + COLOURPET) = 0 { !SOURCE "editrom40cls.asm"
```

(This matches the relocation logic in `editrom40hi.asm` and the pattern already used for `editrom40lm.asm` and `editrom40scrollup.asm`.)
