### PR TITLE
Fix black fg / black bg on startup

### DIFF
--- a/colourpet.asm
+++ b/colourpet.asm
@@ -89,8 +89,9 @@ ccabort		RTS
 ; It sets the default foreground, background and border colours.
 
 ColourPET_Init
+		JSR INIT_EDITOR					; Do Normal Initialization
 
-!IF COLOURMODE = 1 {						;---- Analog Colour Mode
+!IF COLOURMODE = 1 {					;---- Analog Colour Mode
 		LDA COLOURPAL					; Default Colour Palette# = 0
 		STA ColourPNum					; Palette# for Analog Mode
 }
@@ -103,7 +104,6 @@ ColourPET_Init
 		JSR ColourPET_SyncPointers
 		LDA #5
 		STA ColourV	;*** DEBUG
-		JSR INIT_EDITOR					; Do Normal Initialization
 
 ;*********************************************************************************************************
 ;** Set Colour


### PR DESCRIPTION
The ColourPET display starts with black foreground on black background, making text invisible until a color code is printed.

This happens because `INIT_EDITOR` clears a large section of the zeropage ($8D-FA), which clobbered ColourFG, ColourBG, etc.

```asm
INIT_EDITOR
    LDX #$6d
    LDA #0
INITED1 STA JIFFY_CLOCK,X   ; JIFFY_CLOCK = $8D
    DEX
    BPL INITED1             ; Clears $8D through $FA
```

The fix proposed below is to simply call INIT_EDITOR first, then set the colour variables.

This appears to work for RGBI mode, but I didn't study the code closely or consider other modes.  (Creating a draft pull request until one of us has more time to verify this is a good fix.)

